### PR TITLE
libc : memcpy : allow to disable opt for some targets

### DIFF
--- a/libc/arch-arm/cortex-a7/cortex-a7.mk
+++ b/libc/arch-arm/cortex-a7/cortex-a7.mk
@@ -3,7 +3,6 @@ libc_bionic_src_files_arm += \
 
 libc_bionic_src_files_arm += \
     arch-arm/cortex-a15/bionic/memchr.S \
-    arch-arm/cortex-a15/bionic/memcpy.S \
     arch-arm/cortex-a15/bionic/strcat.S \
     arch-arm/cortex-a15/bionic/__strcat_chk.S \
     arch-arm/cortex-a15/bionic/strcmp.S \
@@ -16,3 +15,12 @@ libc_bionic_src_files_arm += \
 
 libc_bionic_src_files_arm += \
     arch-arm/denver/bionic/memmove.S \
+
+# Optimization not required for some targets
+ifeq ($(TARGET_CPU_MEMCPY_OPT_DISABLE),true)
+libc_bionic_src_files_arm += \
+    arch-arm/cortex-a7/bionic/memcpy.S
+else
+libc_bionic_src_files_arm += \
+    arch-arm/cortex-a15/bionic/memcpy.S
+endif


### PR DESCRIPTION
Missing change lost TARGET_CPU_MEMCPY_OPT_DISABLE feature
